### PR TITLE
chore: replace make vet and fmt with golangci-lint

### DIFF
--- a/.github/common-actions/unit-test/action.yaml
+++ b/.github/common-actions/unit-test/action.yaml
@@ -13,4 +13,4 @@ runs:
   steps:
     - name: Run Test
       shell: bash
-      run: go test ${{ inputs.working-directory }}/...
+      run: make test-nolint

--- a/Makefile
+++ b/Makefile
@@ -98,14 +98,17 @@ lint: golangci-lint ## Run all linters, controlled by .golangci.yml
 # Setting GOPATH is a workaround for https://github.com/golangci/golangci-lint/issues/3828
 	GOPATH=`go env GOPATH` $(GOLANGCI_LINT) run
 
+.PHONY: test-nolint
+test-nolint: manifests generate envtest
+
 .PHONY: test
-test: manifests generate lint envtest ## Run tests.
+test: test-nolint lint ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
 
 .PHONY: build
-build: manifests generate lint ## Build manager binary.
+build: manifests generate ## Build manager binary.
 	go build -o bin/manager main.go
 
 .PHONY: run
@@ -116,7 +119,7 @@ run: manifests generate lint ## Run a controller from your host.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
 .PHONY: docker-push

--- a/Makefile
+++ b/Makefile
@@ -93,26 +93,23 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-.PHONY: fmt
-fmt: ## Run go fmt against code.
-	go fmt ./...
-
-.PHONY: vet
-vet: ## Run go vet against code.
-	go vet ./...
+.PHONY: lint
+lint: golangci-lint ## Run all linters, controlled by .golangci.yml
+# Setting GOPATH is a workaround for https://github.com/golangci/golangci-lint/issues/3828
+	GOPATH=`go env GOPATH` $(GOLANGCI_LINT) run
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
+test: manifests generate lint envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
 
 .PHONY: build
-build: manifests generate fmt vet ## Build manager binary.
+build: manifests generate lint ## Build manager binary.
 	go build -o bin/manager main.go
 
 .PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
+run: manifests generate lint ## Run a controller from your host.
 	go run ./main.go
 
 # If you wish built the manager image targeting other platforms you can use the --platform flag.
@@ -177,10 +174,12 @@ $(LOCALBIN):
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.11.1
+GOLANGCI_LINT_VERSION ?=v1.52.2
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -202,6 +201,16 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+GOLANGCI_LINT_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary. If wrong version is installed, it will be removed before downloading.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	@if test -x $(LOCALBIN)/golangci-lint && ! $(LOCALBIN)/golangci-lint version | grep -q $(KUSTOMIZE_VERSION); then \
+		echo "$(LOCALBIN)/golangci-lint version is not expected $(GOLANGCI_LINT_VERSION). Removing it before installing."; \
+		rm -rf $(LOCALBIN)/golangci-lint; \
+	fi
+	test -s $(LOCALBIN)/golangci-lint || { curl -sSfL $(GOLANGCI_LINT_INSTALL_SCRIPT) | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION); }
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
In CI, this project already uses golangci-lint to configure and run all of its various linters. Run the same thing locally in "make lint" and as part of make targets that previously ran "go vet" and "go fmt". This has the added benefit of commands like "make build" and "make test" causing diffs, since it is difficut to run "go fmt" without it actually modifying files.

Add a new "golangci-lint" target that downloads a project-specific copy of golangci-lint to the project's bin directory, similar to what we do for kustomize and other tools. The version is set to v1.52.2, which is the same we have configured in CI.

Add a new "make lint" target to run the linter and get rid of the old "vet" and "fmt" targets since our lint list checks those. Also restructure the make targets and CI slightly so that when CI runs builds, it doesn't implicitly run the linter again, since it has already done so in a previous action.