### PR TITLE
fix: cluster requeue

### DIFF
--- a/api/v1alpha1/rosacluster_types.go
+++ b/api/v1alpha1/rosacluster_types.go
@@ -359,6 +359,12 @@ type ROSAClusterList struct {
 	Items           []ROSACluster `json:"items"`
 }
 
+// GetClusterID gets the status.clusterID field from the object.  It is used to
+// satisfy the Workload interface.
+func (cluster *ROSACluster) GetClusterID() string {
+	return cluster.Status.ClusterID
+}
+
 // GetConditions returns the status.conditions field from the object.  It is used to
 // satisfy the Workload interface.
 func (cluster *ROSACluster) GetConditions() []metav1.Condition {

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rh-mobb/ocm-operator/pkg/conditions"
 	"github.com/rh-mobb/ocm-operator/pkg/kubernetes"
 	"github.com/rh-mobb/ocm-operator/pkg/triggers"
-	"github.com/rh-mobb/ocm-operator/pkg/workload"
 )
 
 var (
@@ -30,16 +29,6 @@ const (
 
 	LogLevelDebug = 5
 )
-
-// Request represents a request that was sent to the controller that
-// caused reconciliation.  It is used to track the status during the steps of
-// controller reconciliation and pass information.  It should be able to
-// return back the original object, in its pure form, that was discovered
-// when the request was triggered.
-type Request interface {
-	GetObject() workload.Workload
-	GetName() string
-}
 
 // Controller represents the object that is performing the reconciliation
 // action.
@@ -179,15 +168,4 @@ func RemoveFinalizer(ctx context.Context, r kubernetes.Client, object client.Obj
 	}
 
 	return nil
-}
-
-// LogValues returns a consistent set of values for a request.
-func LogValues(request Request) []interface{} {
-	object := request.GetObject()
-
-	return []interface{}{
-		"kind", object.GetObjectKind().GroupVersionKind().Kind,
-		"resource", fmt.Sprintf("%s/%s", object.GetNamespace(), object.GetName()),
-		"name", request.GetName(),
-	}
 }

--- a/controllers/gitlabidentityprovider/controller.go
+++ b/controllers/gitlabidentityprovider/controller.go
@@ -30,6 +30,7 @@ import (
 
 	ocmv1alpha1 "github.com/rh-mobb/ocm-operator/api/v1alpha1"
 	"github.com/rh-mobb/ocm-operator/controllers"
+	"github.com/rh-mobb/ocm-operator/pkg/triggers"
 )
 
 const (
@@ -73,6 +74,9 @@ func (r *Controller) ReconcileCreate(req controllers.Request) (ctrl.Result, erro
 	// execute the phases
 	// TODO: see TODO in api/v1alpha1/gitlabidentityprovider_types.go file for explanation.
 	return controllers.Execute(request, request.ControllerRequest, []controllers.Phase{
+		{Name: "HandleUpstreamCluster", Function: func() (ctrl.Result, error) {
+			return controllers.HandleClusterPhase(request, request.Reconciler.Connection, triggers.Create, request.Log)
+		}},
 		{Name: "GetCurrentState", Function: func() (ctrl.Result, error) { return r.GetCurrentState(request) }},
 		// {Name: "ApplyGitLab", Function: func() (ctrl.Result, error) { return r.ApplyGitLab(request) }},
 		{Name: "ApplyIdentityProvider", Function: func() (ctrl.Result, error) { return r.ApplyIdentityProvider(request) }},

--- a/controllers/gitlabidentityprovider/phases.go
+++ b/controllers/gitlabidentityprovider/phases.go
@@ -22,18 +22,12 @@ var (
 // is stored in OpenShift Cluster Manager.  It will be compared against the desired state which exists
 // within the OpenShift cluster in which this controller is reconciling against.
 func (r *Controller) GetCurrentState(request *GitLabIdentityProviderRequest) (ctrl.Result, error) {
-	// retrieve the cluster id
-	clusterID := request.Original.Status.ClusterID
-	if clusterID == "" {
-		if err := request.updateStatusCluster(); err != nil {
-			return controllers.RequeueAfter(defaultGitLabIdentityProviderRequeue), err
-		}
-
-		clusterID = request.Original.Status.ClusterID
-	}
-
 	// get the generic identity provider object from ocm
-	request.OCMClient = ocm.NewIdentityProviderClient(request.Reconciler.Connection, request.Desired.Spec.DisplayName, clusterID)
+	request.OCMClient = ocm.NewIdentityProviderClient(
+		request.Reconciler.Connection,
+		request.Desired.Spec.DisplayName,
+		request.Original.Status.ClusterID,
+	)
 
 	idp, err := request.OCMClient.Get()
 	if err != nil {

--- a/controllers/gitlabidentityprovider/request.go
+++ b/controllers/gitlabidentityprovider/request.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
+	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -135,40 +136,31 @@ func (request *GitLabIdentityProviderRequest) GetName() string {
 	return request.Desired.Spec.DisplayName
 }
 
-// updateStatusCluster updates fields related to the cluster in which the gitlab identity provider resides in.
-// TODO: centralize this function into controllers or conditions package.
-func (request *GitLabIdentityProviderRequest) updateStatusCluster() error {
-	// retrieve the cluster id
-	clusterClient := ocm.NewClusterClient(request.Reconciler.Connection, request.Desired.Spec.ClusterName)
-	cluster, err := clusterClient.Get()
-	if err != nil || cluster == nil {
-		return fmt.Errorf(
-			"unable to retrieve cluster from ocm [name=%s] - %w",
-			request.Desired.Spec.ClusterName,
-			err,
-		)
+// GetClusterName returns the cluster name that this object belongs to.
+func (request *GitLabIdentityProviderRequest) GetClusterName() string {
+	return request.Desired.Spec.ClusterName
+}
+
+// GetContext returns the context of the request.
+func (request *GitLabIdentityProviderRequest) GetContext() context.Context {
+	return request.Context
+}
+
+// GetReconciler returns the context of the request.
+func (request *GitLabIdentityProviderRequest) GetReconciler() kubernetes.Client {
+	return request.Reconciler
+}
+
+// SetClusterStatus sets the relevant cluster fields in the status.  It is used
+// to satisfy the controllers.Request interface.
+func (request *GitLabIdentityProviderRequest) SetClusterStatus(cluster *clustersmgmtv1.Cluster) {
+	if request.Original.Status.ClusterID == "" {
+		request.Original.Status.ClusterID = cluster.ID()
 	}
 
-	// if the cluster id is missing return an error
-	if cluster.ID() == "" {
-		return fmt.Errorf("missing cluster id in response - %w", ErrMissingClusterID)
+	if request.Original.Status.CallbackURL == "" {
+		request.Original.Status.CallbackURL = ocm.GetCallbackURL(cluster, request.Desired.Spec.DisplayName)
 	}
-
-	// keep track of the original object
-	original := request.Original.DeepCopy()
-	request.Original.Status.ClusterID = cluster.ID()
-	request.Original.Status.CallbackURL = ocm.GetCallbackURL(cluster, request.Desired.Spec.DisplayName)
-
-	// store the cluster id in the status
-	if err := kubernetes.PatchStatus(request.Context, request.Reconciler, original, request.Original); err != nil {
-		return fmt.Errorf(
-			"unable to update status.clusterID=%s - %w",
-			cluster.ID(),
-			err,
-		)
-	}
-
-	return nil
 }
 
 func (request *GitLabIdentityProviderRequest) desired() bool {

--- a/controllers/ldapidentityprovider/controller.go
+++ b/controllers/ldapidentityprovider/controller.go
@@ -30,6 +30,7 @@ import (
 
 	ocmv1alpha1 "github.com/rh-mobb/ocm-operator/api/v1alpha1"
 	"github.com/rh-mobb/ocm-operator/controllers"
+	"github.com/rh-mobb/ocm-operator/pkg/triggers"
 )
 
 // Controller reconciles a LDAPIdentityProvider object.
@@ -68,6 +69,9 @@ func (r *Controller) ReconcileCreate(req controllers.Request) (ctrl.Result, erro
 
 	// execute the phases
 	return controllers.Execute(request, request.ControllerRequest, []controllers.Phase{
+		{Name: "HandleUpstreamCluster", Function: func() (ctrl.Result, error) {
+			return controllers.HandleClusterPhase(request, request.Reconciler.Connection, triggers.Create, request.Log)
+		}},
 		{Name: "GetCurrentState", Function: func() (ctrl.Result, error) { return r.GetCurrentState(request) }},
 		{Name: "Apply", Function: func() (ctrl.Result, error) { return r.ApplyIdentityProvider(request) }},
 		{Name: "Complete", Function: func() (ctrl.Result, error) { return r.Complete(request) }},

--- a/controllers/ldapidentityprovider/phases.go
+++ b/controllers/ldapidentityprovider/phases.go
@@ -22,18 +22,12 @@ const (
 // is stored in OpenShift Cluster Manager.  It will be compared against the desired state which exists
 // within the OpenShift cluster in which this controller is reconciling against.
 func (r *Controller) GetCurrentState(request *LDAPIdentityProviderRequest) (ctrl.Result, error) {
-	// retrieve the cluster id
-	clusterID := request.Original.Status.ClusterID
-	if clusterID == "" {
-		if err := request.updateStatusCluster(); err != nil {
-			return controllers.RequeueAfter(defaultLDAPIdentityProviderRequeue), err
-		}
-
-		clusterID = request.Original.Status.ClusterID
-	}
-
 	// get the generic identity provider object from ocm
-	request.OCMClient = ocm.NewIdentityProviderClient(request.Reconciler.Connection, request.Desired.Spec.DisplayName, clusterID)
+	request.OCMClient = ocm.NewIdentityProviderClient(
+		request.Reconciler.Connection,
+		request.Desired.Spec.DisplayName,
+		request.Original.Status.ClusterID,
+	)
 
 	idp, err := request.OCMClient.Get()
 	if err != nil {

--- a/controllers/machinepool/controller.go
+++ b/controllers/machinepool/controller.go
@@ -30,6 +30,7 @@ import (
 
 	ocmv1alpha1 "github.com/rh-mobb/ocm-operator/api/v1alpha1"
 	"github.com/rh-mobb/ocm-operator/controllers"
+	"github.com/rh-mobb/ocm-operator/pkg/triggers"
 )
 
 const (
@@ -72,6 +73,9 @@ func (r *Controller) ReconcileCreate(req controllers.Request) (ctrl.Result, erro
 
 	// execute the phases
 	return controllers.Execute(request, request.ControllerRequest, []controllers.Phase{
+		{Name: "HandleUpstreamCluster", Function: func() (ctrl.Result, error) {
+			return controllers.HandleClusterPhase(request, request.Reconciler.Connection, triggers.Create, request.Log)
+		}},
 		{Name: "GetCurrentState", Function: func() (ctrl.Result, error) { return r.GetCurrentState(request) }},
 		{Name: "Apply", Function: func() (ctrl.Result, error) { return r.Apply(request) }},
 		{Name: "WaitUntilReady", Function: func() (ctrl.Result, error) { return r.WaitUntilReady(request) }},

--- a/controllers/machinepool/phases.go
+++ b/controllers/machinepool/phases.go
@@ -19,9 +19,6 @@ import (
 // GetCurrentState gets the current state of the MachinePool resource.  The current state of the MachinePool resource
 // is stored in OpenShift Cluster Manager.  It will be compared against the desired state which exists
 // within the OpenShift cluster in which this controller is reconciling against.
-// TODO: needs refactor
-//
-//nolint:cyclop
 func (r *Controller) GetCurrentState(request *MachinePoolRequest) (ctrl.Result, error) {
 	// retrieve the machine pool (or node pool for hosted control plane clusters)
 	var pool interface{}

--- a/controllers/machinepool/phases.go
+++ b/controllers/machinepool/phases.go
@@ -23,26 +23,16 @@ import (
 //
 //nolint:cyclop
 func (r *Controller) GetCurrentState(request *MachinePoolRequest) (ctrl.Result, error) {
-	// retrieve the cluster id
-	clusterID := request.Original.Status.ClusterID
-	if clusterID == "" {
-		if err := request.updateStatusCluster(); err != nil {
-			return controllers.RequeueAfter(defaultMachinePoolRequeue), err
-		}
-
-		clusterID = request.Original.Status.ClusterID
-	}
-
 	// retrieve the machine pool (or node pool for hosted control plane clusters)
 	var pool interface{}
 
 	var err error
 
 	if request.Original.Status.Hosted {
-		poolClient := ocm.NewNodePoolClient(r.Connection, request.Desired.Spec.DisplayName, clusterID)
+		poolClient := ocm.NewNodePoolClient(r.Connection, request.Desired.Spec.DisplayName, request.Original.Status.ClusterID)
 		pool, err = poolClient.Get()
 	} else {
-		poolClient := ocm.NewMachinePoolClient(r.Connection, request.Desired.Spec.DisplayName, clusterID)
+		poolClient := ocm.NewMachinePoolClient(r.Connection, request.Desired.Spec.DisplayName, request.Original.Status.ClusterID)
 		pool, err = poolClient.Get()
 	}
 

--- a/controllers/machinepool/request.go
+++ b/controllers/machinepool/request.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
+	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -122,6 +123,39 @@ func (request *MachinePoolRequest) GetName() string {
 	return request.Desired.Spec.DisplayName
 }
 
+// GetClusterName returns the cluster name that this object belongs to.
+func (request *MachinePoolRequest) GetClusterName() string {
+	return request.Desired.Spec.ClusterName
+}
+
+// GetContext returns the context of the request.
+func (request *MachinePoolRequest) GetContext() context.Context {
+	return request.Context
+}
+
+// GetReconciler returns the context of the request.
+func (request *MachinePoolRequest) GetReconciler() kubernetes.Client {
+	return request.Reconciler
+}
+
+// SetClusterStatus sets the relevant cluster fields in the status.  It is used
+// to satisfy the controllers.Request interface.
+func (request *MachinePoolRequest) SetClusterStatus(cluster *clustersmgmtv1.Cluster) {
+	if request.Original.Status.ClusterID == "" {
+		request.Original.Status.ClusterID = cluster.ID()
+	}
+
+	if len(request.Original.Status.AvailabilityZones) == 0 {
+		request.Original.Status.AvailabilityZones = cluster.Nodes().AvailabilityZones()
+	}
+
+	if len(request.Original.Status.Subnets) == 0 {
+		request.Original.Status.Subnets = cluster.AWS().SubnetIDs()
+	}
+
+	request.Original.Status.Hosted = cluster.Hypershift().Enabled()
+}
+
 func (request *MachinePoolRequest) desired() bool {
 	if request.Desired == nil || request.Current == nil {
 		return false
@@ -135,43 +169,6 @@ func (request *MachinePoolRequest) desired() bool {
 		request.Desired.Spec,
 		request.Current.Spec,
 	)
-}
-
-// updateStatusCluster updates fields related to the cluster in which the machine pool resides in.
-func (request *MachinePoolRequest) updateStatusCluster() error {
-	// retrieve the cluster id
-	clusterClient := ocm.NewClusterClient(request.Reconciler.Connection, request.Desired.Spec.ClusterName)
-	cluster, err := clusterClient.Get()
-	if err != nil || cluster == nil {
-		return fmt.Errorf(
-			"unable to retrieve cluster from ocm [name=%s] - %w",
-			request.Desired.Spec.ClusterName,
-			err,
-		)
-	}
-
-	// if the cluster id is missing return an error
-	if cluster.ID() == "" {
-		return fmt.Errorf("missing cluster id in response - %w", ErrMissingClusterID)
-	}
-
-	// keep track of the original object
-	original := request.Original.DeepCopy()
-	request.Original.Status.ClusterID = cluster.ID()
-	request.Original.Status.AvailabilityZones = cluster.Nodes().AvailabilityZones()
-	request.Original.Status.Subnets = cluster.AWS().SubnetIDs()
-	request.Original.Status.Hosted = cluster.Hypershift().Enabled()
-
-	// store the cluster id in the status
-	if err := kubernetes.PatchStatus(request.Context, request.Reconciler, original, request.Original); err != nil {
-		return fmt.Errorf(
-			"unable to update status.clusterID=%s - %w",
-			cluster.ID(),
-			err,
-		)
-	}
-
-	return nil
 }
 
 // createMachinePool creates a machine pool object in OCM.

--- a/controllers/phase.go
+++ b/controllers/phase.go
@@ -2,9 +2,21 @@ package controllers
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/go-logr/logr"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/rh-mobb/ocm-operator/pkg/conditions"
+	"github.com/rh-mobb/ocm-operator/pkg/ocm"
+	"github.com/rh-mobb/ocm-operator/pkg/triggers"
+)
+
+const (
+	defaultMissingUpstreamRequeue = 60 * time.Second
 )
 
 // Phase defines an individual phase in the controller reconciliation process.
@@ -25,6 +37,61 @@ func Execute(request Request, req reconcile.Request, phases ...Phase) (ctrl.Resu
 				err,
 			)
 		}
+	}
+
+	return NoRequeue(), nil
+}
+
+// HandleClusterPhase is the common phase that handles the upstream cluster for a child request.  It
+// should be called with a wrapper function in order to satisfy the Phase.Function field.
+func HandleClusterPhase(
+	request ClusterChildRequest,
+	connection *sdk.Connection,
+	trigger triggers.Trigger,
+	logger logr.Logger,
+) (ctrl.Result, error) {
+	cluster, err := HandleUpstreamCluster(request, ocm.NewClusterClient(connection, request.GetClusterName()))
+	if err != nil {
+		return RequeueAfter(defaultMissingUpstreamRequeue), fmt.Errorf(
+			"unable to handle upstream cluster: [%s] - %w",
+			request.GetClusterName(),
+			err,
+		)
+	}
+
+	clusterExists := (cluster != nil)
+
+	// set condition for a missing or existing cluster
+	if err := conditions.Update(
+		request.GetContext(),
+		request.GetReconciler(),
+		request.GetObject(),
+		conditions.UpstreamCluster(trigger, clusterExists),
+	); err != nil {
+		return RequeueAfter(defaultMissingUpstreamRequeue), fmt.Errorf(
+			"unable to update status on cluster: [%s] - %w",
+			request.GetClusterName(),
+			err,
+		)
+	}
+
+	// return if the cluster exists
+	if !clusterExists {
+		logger.Info(fmt.Sprintf("cluster [%s] does not exist...requeueing", request.GetClusterName()), LogValues(request)...)
+
+		return RequeueAfter(defaultMissingUpstreamRequeue), nil
+	}
+
+	// return if the cluster is not ready
+	if cluster.State() != clustersmgmtv1.ClusterStateReady {
+		logger.Info(
+			fmt.Sprintf(
+				"cluster [%s] with state [%s] is not ready...requeueing",
+				request.GetClusterName(),
+				cluster.State(),
+			), LogValues(request)...)
+
+		return RequeueAfter(defaultMissingUpstreamRequeue), nil
 	}
 
 	return NoRequeue(), nil

--- a/controllers/request.go
+++ b/controllers/request.go
@@ -1,0 +1,117 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+
+	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	"github.com/rh-mobb/ocm-operator/pkg/kubernetes"
+	"github.com/rh-mobb/ocm-operator/pkg/ocm"
+	"github.com/rh-mobb/ocm-operator/pkg/workload"
+)
+
+var (
+	ErrMissingClusterID = errors.New("unable to find cluster id")
+)
+
+const (
+	errRetrieveClusterMessage = "unable to retrieve cluster from ocm"
+)
+
+// Request represents a request that was sent to the controller that
+// caused reconciliation.  It is used to track the status during the steps of
+// controller reconciliation and pass information.  It should be able to
+// return back the original object, in its pure form, that was discovered
+// when the request was triggered.
+type Request interface {
+	GetObject() workload.Workload
+	GetName() string
+}
+
+// ClusterChildRequest is similar to a request, but represents a request that
+// is a child request and relies upon an existing cluster.
+type ClusterChildRequest interface {
+	Request
+
+	GetClusterName() string
+	GetContext() context.Context
+	GetReconciler() kubernetes.Client
+	SetClusterStatus(*clustersmgmtv1.Cluster)
+}
+
+// HandleUpstreamCluster finds the actual cluster from OCM and sets the relevant cluster status fields on
+// the request.
+//
+//nolint:nestif
+func HandleUpstreamCluster(request ClusterChildRequest, client *ocm.ClusterClient) (cluster *clustersmgmtv1.Cluster, err error) {
+	// retrieve the cluster
+	if request.GetObject().GetClusterID() == "" {
+		// retrieve the cluster from ocm
+		cluster, err = client.Get()
+		if err != nil {
+			return cluster, fmt.Errorf("%s: [%s] - %w", errRetrieveClusterMessage, client.Name, err)
+		}
+
+		if cluster == nil {
+			return nil, nil
+		}
+
+		// if the cluster id is missing return an error
+		if cluster.ID() == "" {
+			return cluster, fmt.Errorf("%s: [%s] - %w", errRetrieveClusterMessage, client.Name, ErrMissingClusterID)
+		}
+	} else {
+		// retrieve the cluster from ocm by id
+		response, err := client.For(request.GetObject().GetClusterID()).Get().Send()
+		if err != nil {
+			if response.Status() == http.StatusNotFound {
+				return cluster, nil
+			}
+		}
+
+		cluster = response.Body()
+	}
+
+	// keep track of the original object
+	original := request.GetObject()
+
+	// update the object
+	request.SetClusterStatus(cluster)
+
+	// if the original object and the current objects are equal, we do not require a
+	// status update, so we can simply return the cluster.
+	if reflect.DeepEqual(original, request.GetObject()) {
+		return cluster, nil
+	}
+
+	// update the status containing the new values
+	if err := kubernetes.PatchStatus(
+		request.GetContext(),
+		request.GetReconciler(),
+		original,
+		request.GetObject(),
+	); err != nil {
+		return cluster, fmt.Errorf(
+			"unable to update status.clusterID=%s - %w",
+			cluster.ID(),
+			err,
+		)
+	}
+
+	return cluster, nil
+}
+
+// LogValues returns a consistent set of values for a request.
+func LogValues(request Request) []interface{} {
+	object := request.GetObject()
+
+	return []interface{}{
+		"kind", object.GetObjectKind().GroupVersionKind().Kind,
+		"resource", fmt.Sprintf("%s/%s", object.GetNamespace(), object.GetName()),
+		"name", request.GetName(),
+	}
+}

--- a/controllers/rosacluster/controller.go
+++ b/controllers/rosacluster/controller.go
@@ -105,6 +105,7 @@ func (r *Controller) ReconcileDelete(req controllers.Request) (ctrl.Result, erro
 
 	// execute the phases
 	return controllers.Execute(request, request.ControllerRequest, []controllers.Phase{
+		{Name: "FindChildObjects", Function: func() (ctrl.Result, error) { return r.FindChildObjects(request) }},
 		{Name: "DestroyCluster", Function: func() (ctrl.Result, error) { return r.DestroyCluster(request) }},
 		{Name: "WaitUntilMissing", Function: func() (ctrl.Result, error) { return r.WaitUntilMissing(request) }},
 		{Name: "DestroyOperatorRoles", Function: func() (ctrl.Result, error) { return r.DestroyOperatorRoles(request) }},

--- a/controllers/rosacluster/phases.go
+++ b/controllers/rosacluster/phases.go
@@ -264,7 +264,7 @@ func (r *Controller) DestroyOIDC(request *ROSAClusterRequest) (ctrl.Result, erro
 	// only destroy the oidc configuration if we have not already done so
 	if !conditions.IsSet(OIDCConfigDeleted(), request.Original) {
 		request.Log.Info("deleting oidc config", controllers.LogValues(request)...)
-		if err := request.AWSClient.DeleteOIDCProvider(request.Original.Status.OIDCProviderARN); err != nil {
+		if err := request.Reconciler.AWSClient.DeleteOIDCProvider(request.Original.Status.OIDCProviderARN); err != nil {
 			return controllers.RequeueAfter(defaultClusterRequeue), fmt.Errorf(
 				"unable to delete oidc config - %w",
 				err,

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -14,9 +14,12 @@ import (
 )
 
 const (
-	conditionTypeReconciling         = "Reconciling"
-	conditionMessageReconcilingStart = "beginning reconciliation"
-	conditionMessageReconcilingStop  = "ending reconciliation"
+	conditionTypeReconciling               = "Reconciling"
+	conditionTypeUpstreamClusterExists     = "UpstreamClusterExists"
+	conditionMessageReconcilingStart       = "beginning reconciliation"
+	conditionMessageReconcilingStop        = "ending reconciliation"
+	conditionMessageUpstreamClusterExists  = "upstream cluster exists"
+	conditionMessageUpstreamClusterMissing = "upstream cluster is missing"
 )
 
 var (
@@ -44,6 +47,29 @@ func Reconciled(trigger triggers.Trigger) *metav1.Condition {
 		Status:             metav1.ConditionFalse,
 		Reason:             trigger.String(),
 		Message:            conditionMessageReconcilingStop,
+	}
+}
+
+// UpstreamCluster returns a condition that gives the status of the upstream cluster.
+func UpstreamCluster(trigger triggers.Trigger, exists bool) *metav1.Condition {
+	var message string
+
+	var status metav1.ConditionStatus
+
+	if exists {
+		message = conditionMessageUpstreamClusterExists
+		status = metav1.ConditionTrue
+	} else {
+		message = conditionMessageUpstreamClusterMissing
+		status = metav1.ConditionFalse
+	}
+
+	return &metav1.Condition{
+		Type:               conditionTypeUpstreamClusterExists,
+		LastTransitionTime: metav1.Now(),
+		Status:             status,
+		Reason:             trigger.String(),
+		Message:            message,
 	}
 }
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1,14 +1,26 @@
 package workload
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rh-mobb/ocm-operator/pkg/kubernetes"
 )
 
 // Workload represents the actual object that is being reconciled.
 type Workload interface {
 	client.Object
 
+	GetClusterID() string
 	GetConditions() []metav1.Condition
 	SetConditions([]metav1.Condition)
+}
+
+// ClusterChild is a specialized workload that has a parent cluster.
+type ClusterChild interface {
+	Workload
+
+	ExistsForClusterID(context.Context, kubernetes.Client, string) (bool, error)
 }


### PR DESCRIPTION
1. If a cluster is missing when and object is submitted (e.g. MachinePool)
the operator will requeue until the cluster exists and then continue
its normal workflow.
    
2. Refactor removal of duplicate updateStatusCluster code.
    
3. If a cluster is deleted and has related objects, the cluster
deletion is blocked until all related objects are missing.

4. Moves the AWS Client creation to the controller object to
prevent multiple session creations.